### PR TITLE
Fix visited logic

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -238,6 +238,7 @@ describe('mongoose-track-changes', () => {
       });
       test('Multiple operations on the same unexisting path, initial true', () => {
         saved_task.set("initial_true", true);
+        expect(saved_task.pathHasChanged("/initial_true")).toBe(false);
         saved_task.set("initial_true", false);
         expect(saved_task.pathHasChanged("/initial_true")).toBe(true);
       });


### PR DESCRIPTION
Avoid marking as visited when there are no changes.
This fixes a bug that caused changes to be undetected when setting a field which did not previoulsy exist in the document.